### PR TITLE
Update to API, moved from utils to transform

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -82,35 +82,30 @@ matrixprofile.algorithms.scrimp_plus_plus
 
 .. autofunction:: matrixprofile.algorithms.scrimp_plus_plus
 
-matrixprofile.utils.apply_av
+matrixprofile.transform.apply_av
 ============================
 
-.. autofunction:: matrixprofile.utils.apply_av
+.. autofunction:: matrixprofile.transform.apply_av
 
-matrixprofile.utils.apply_av
+matrixprofile.transform.make_default_av
 ============================
 
-.. autofunction:: matrixprofile.utils.apply_av
+.. autofunction:: matrixprofile.transform.make_default_av
 
-matrixprofile.utils.make_default_av
+matrixprofile.transform.make_complexity_av
 ============================
 
-.. autofunction:: matrixprofile.utils.make_default_av
+.. autofunction:: matrixprofile.transform.make_complexity_av
 
-matrixprofile.utils.make_complexity_av
+matrixprofile.transform.make_meanstd_av
 ============================
 
-.. autofunction:: matrixprofile.utils.make_complexity_av
+.. autofunction:: matrixprofile.transform.make_meanstd_av
 
-matrixprofile.utils.make_meanstd_av
+matrixprofile.transform.make_clipping_av
 ============================
 
-.. autofunction:: matrixprofile.utils.make_meanstd_av
-
-matrixprofile.utils.make_clipping_av
-============================
-
-.. autofunction:: matrixprofile.utils.make_clipping_av
+.. autofunction:: matrixprofile.transform.make_clipping_av
 
 matrixprofile.utils.empty_mp
 ============================


### PR DESCRIPTION
Realized that there was one minor issue in documentation where the AV functions were listed as being in utils instead of transform. Documentation has now been updated to reflect this change.