### PR TITLE
fix calculating snippets

### DIFF
--- a/matrixprofile/algorithms/snippets.py
+++ b/matrixprofile/algorithms/snippets.py
@@ -59,8 +59,6 @@ def snippets(ts, snippet_size, num_snippets=2, window_size=None):
     if window_size >= snippet_size:
         raise ValueError('window_size must be smaller than snippet_size')
 
-    used_window = int(np.round(snippet_size * window_size / 100))
-
     # pad end of time series with zeros
     num_zeros = int(snippet_size * np.ceil(n / snippet_size) - n)
     ts = np.append(ts, np.zeros(num_zeros))
@@ -70,7 +68,7 @@ def snippets(ts, snippet_size, num_snippets=2, window_size=None):
     distances = []
 
     for j, i in enumerate(indices):
-        distance = mpdist_vector(ts, ts[i:(i + snippet_size)], used_window)
+        distance = mpdist_vector(ts, ts[i:(i + snippet_size - 1)], int(window_size))
         distances.append(distance)
 
     distances = np.array(distances)	

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -39,6 +39,10 @@ def test_snippets():
     assert(result[0]['index'] == 384)
     assert(result[1]['index'] == 640)
 
+    snippet_size = 8
+    result = snippets(ts, snippet_size, window_size=snippet_size / 2)
+    assert(result[0]['index'] == 72)
+    assert(result[1]['index'] == 784)
 
 def test_invalid_snippet_size():
     ts = np.arange(100)

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -26,12 +26,12 @@ def test_snippets():
     snippet_size = 64
 
     result = snippets(ts, snippet_size, window_size=w)
-    assert(result[0]['index'] == 192)
+    assert(result[0]['index'] == 384)
     assert(result[1]['index'] == 704)
 
     # test inferred window size of snippet size / 2
     result = snippets(ts, snippet_size)
-    assert(result[0]['index'] == 192)
+    assert(result[0]['index'] == 384)
     assert(result[1]['index'] == 704)
 
     snippet_size = 128


### PR DESCRIPTION
fixes #27 

**Test:**

There was a test failing. I used the `R` implementation to double check what the expected result should be and found that the expected value of the test was incorrect.

```r
library(readr)
library(tsmp)

data <- read_csv("https://raw.githubusercontent.com/matrix-profile-foundation/matrixprofile/master/tests/sampledata.txt", col_names = FALSE)
data = unlist(data, use.names=FALSE)

snippets <- find_snippet(data, 64, n_snippets = 2, 32)

print(snippets)

Snippet
-------
Snippets found = 2 
Snippets indexes = 385 705 
Snippets fractions = 72.87% 27.13% 
Snippet size = 64 
```