### PR TITLE
Fix negative square because of floating point representations

### DIFF
--- a/matrixprofile/cycore.pyx
+++ b/matrixprofile/cycore.pyx
@@ -152,6 +152,9 @@ def moving_avg_std(double[:] a, unsigned int w):
         sig_sq[i] = sq_sums[i] / w - mu[i] * mu[i]
     
     for i in range(profile_len):
-        sig[i] = sqrt(sig_sq[i])
+        if sig_sq[i] < 0:
+            sig[i] = 0
+        else:
+            sig[i] = sqrt(sig_sq[i])
     
     return (mu, sig)

--- a/tests/test_cycore.py
+++ b/tests/test_cycore.py
@@ -32,6 +32,17 @@ def test_moving_avg_std():
     np.testing.assert_almost_equal(std, std_desired)
 
 
+def test_it_should_not_produce_nan_values_when_std_is_almost_zero():
+    a = np.array([10.1, 10.1, 10.1, 10.1, 10.1, 10.1, 10.1], dtype='d')
+    mu, std = cycore.moving_avg_std(a, 3)
+
+    mu_desired = np.array([10.1, 10.1, 10.1, 10.1, 10.1])
+    std_desired = np.array([0, 0, 0, 0, 0])
+
+    np.testing.assert_almost_equal(mu, mu_desired)
+    np.testing.assert_almost_equal(std, std_desired)
+
+
 def test_moving_muinvn():
     a = np.array([1, 2, 3, 4, 5, 6], dtype='d')
     mu, std = cycore.muinvn(a, 3)


### PR DESCRIPTION
When calculating snippets, I got a lot of NaN and Inf values, resulting in a crash. I tracked the error down to the `moving_avg_std` function defined in `cycore.pyx`.

Sometimes the result of following line is negative:

https://github.com/matrix-profile-foundation/matrixprofile/blob/68d4fca46df5d9571c03d96874cd19d26b2afa97/matrixprofile/cycore.pyx#L152

This is because of some internal representation of floating points. (e.g. 0.1 + 0.2 == 0.3000004)
Taking the square root of this result, results in a NaN value.

In my example the values were:

- Value of sq_sums[i]: 31116960.0
- Value of w: 360
- Value of mu[i]: 294.0000000000006

=> 31116960.0 / 360 - 294.0000000000006 * 294.0000000000006 < 0
