### PR TITLE
prevent division by zero

### DIFF
--- a/matrixprofile/cycore.pyx
+++ b/matrixprofile/cycore.pyx
@@ -92,7 +92,10 @@ def muinvn(double[:] a, unsigned int w):
             s = s + (((p - (x - z)) + (h[j] - z)) + r[j])
             p = x
 
-        sig[i] = 1 / sqrt(p + s)
+        if p + s == 0:
+            sig[i] = 0
+        else:
+            sig[i] = 1 / sqrt(p + s)
     
     return (mu, sig)
 

--- a/tests/test_cycore.py
+++ b/tests/test_cycore.py
@@ -35,12 +35,16 @@ def test_moving_avg_std():
 def test_it_should_not_produce_nan_values_when_std_is_almost_zero():
     a = np.array([10.1, 10.1, 10.1, 10.1, 10.1, 10.1, 10.1], dtype='d')
     mu, std = cycore.moving_avg_std(a, 3)
+    mu_muinvn, std_muinvn = cycore.muinvn(a, 3)
 
     mu_desired = np.array([10.1, 10.1, 10.1, 10.1, 10.1])
     std_desired = np.array([0, 0, 0, 0, 0])
 
     np.testing.assert_almost_equal(mu, mu_desired)
     np.testing.assert_almost_equal(std, std_desired)
+
+    np.testing.assert_almost_equal(mu_muinvn, mu_desired)
+    np.testing.assert_almost_equal(std_muinvn, std_desired)
 
 
 def test_moving_muinvn():

--- a/tests/test_hierarchical_clustering.py
+++ b/tests/test_hierarchical_clustering.py
@@ -184,13 +184,13 @@ def test_pairwise_dist_valid_simple():
     ]
     w = 8
     dists = pairwise_dist(X, w)
-    expected = np.array([ 0, np.inf, np.inf, np.inf, np.inf, np.inf])
+    expected = np.array([ 0, 4, 4, 4, 4, 4])
     np.testing.assert_equal(dists, expected)
 
     # test with MxN np.ndarray
     X = np.array(X)
     dists = pairwise_dist(X, w)
-    expected = np.array([ 0, np.inf, np.inf, np.inf, np.inf, np.inf])
+    expected = np.array([ 0, 4, 4, 4, 4, 4])
     np.testing.assert_equal(dists, expected)
 
 


### PR DESCRIPTION
When calculating the pairwise distance on a series, I had some infinity values. 
This is only on a series where the standard deviation is almost zero

**Result of the test without the fix:**

```
E           AssertionError: 
E           Arrays are not almost equal to 7 decimals
E           
E           x and y +inf location mismatch:
E            x: array([inf, inf, inf, inf, inf])
E            y: array([0, 0, 0, 0, 0])
```