### PR TITLE
Develop

### DIFF
--- a/matrixprofile/algorithms/mpxinterf.py
+++ b/matrixprofile/algorithms/mpxinterf.py
@@ -1,0 +1,31 @@
+import numpy as np
+import matrixprofile.streamingimpl as mps
+
+
+def mpx(ts, w):
+    ssct = ts.shape[0] - w + 1
+    mu = np.empty(ssct, dtype='d')
+    mu_s = np.empty(ssct, dtype='d') # window length w - 1 skipping first and last
+    invn = np.empty(ssct, dtype='d')
+    minlag = w // 4
+
+    mps.windowed_mean(ts, mu, w)
+    mps.windowed_mean(ts[:-1], mu_s, w-1)
+    mps.windowed_invcnorm(ts, mu, invn, w)
+    rbwd = ts[:ssct-1] - mu[:-1]
+    cbwd = ts[:ssct-1] - mu_s[1:]
+    rfwd = ts[w:] - mu[1:]
+    cfwd = ts[w:] - mu_s[1:]
+
+    mp = np.full(ssct, -1, dtype='d')
+    mpi = np.full(ssct, -1, dtype='i')
+
+    first_row = ts[:w] - mu[0]
+    cov = np.empty(ssct - minlag, dtype='d')   
+ 
+    mps.crosscov(cov, ts[minlag:],  mu[minlag:], first_row)
+
+    # roffset only applies when this is tiled by row, since otherwise the index would be wrong
+    mps.mpx_inner(cov, rbwd, rfwd, cbwd, cfwd, invn, mp, mpi, minlag, 0) 
+
+    return mp, mpi

--- a/matrixprofile/algorithms/streaming.py
+++ b/matrixprofile/algorithms/streaming.py
@@ -1,0 +1,398 @@
+from abc import abstractmethod, ABC
+import matrixprofile.streamingimpl as mps
+import numpy as np
+
+
+class StreamArrayBase(ABC):
+    """ A base class containing the intended interface for an array class specialized
+        for streaming data.
+
+        The specialization of a streaming array is an attempt to provide a queue like interface which is compatible
+        with a pointer like iterator.
+
+        This makes it easy enough to reuse allocated space when trivially copyable data is added to the end of or
+        removed from the beginning of the array without reallocating the entire buffer at each step. It also alleviates
+        the issue of explicitly computing the slice corresponding to a subrange in user code in conjunction with
+        a secondary slice operation.
+
+    """
+
+    @property
+    @abstractmethod
+    def array(self):
+        """ return a C contiguous view to the currently used section of the underlying array or buffer """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def free_count(self):
+        """ number of presently unused entries"""
+        raise NotImplementedError
+
+    @property
+    def max_size(self):
+        """ the maximum array size supported by the current buffer """
+        raise NotImplementedError
+
+    @abstractmethod
+    def __iter__(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def __len__(self):
+        raise NotImplementedError
+
+    # This is intended to propagate slicing so that we can write streamed[...]
+    # rather than streamed.array[...], which brings it close to the verbosity of
+    # inline slicing of subranges
+    @abstractmethod
+    def __getitem__(self, item):
+        raise NotImplementedError
+
+    @abstractmethod
+    def __setitem__(self, key, value):
+        raise NotImplementedError
+
+    @abstractmethod
+    def extend(self, count, fill_value=None):
+        """ Extend array boundary and optionally initialize with fill_value
+            This is inconsistent with Python's internal use of the word "extend", which
+            explicitly takes an iterable, but it's still clearer than other options.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def drop_leading(self, count):
+        """ discard count elements from the beginning of the array
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def resize_buffer(self, size):
+        """ resize the underlying buffer or array. This may raise an error if the updated size is too small to
+            accommodate the currently used or "live" portion of the current buffer.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def append(self, data):
+        """ extend the current array, and copy data to the extended portion. I'm using the term "extend" because
+
+        """
+        raise NotImplementedError
+
+
+class StreamArray(StreamArrayBase):
+    """
+    """
+
+    def __init__(self, size, dtype='d', min_index=0):
+        self.size = size
+        self.min_index = min_index
+        self._array = np.empty(size, dtype=dtype)
+        self.count = 0
+        self.begin_pos = 0
+
+    @property
+    def array(self):
+        return self._array[self.begin_pos:self.begin_pos + self.count]
+
+    @property
+    def max_index(self):
+        """ the absolute time based index of the last buffer element in memory"""
+        return self.min_index + self.count - 1 if self.count != 0 else None
+
+    @property
+    def free_count(self):
+        """ number of presently unused entries"""
+        return self._array.shape[0] - self.count
+
+    @property
+    def max_size(self):
+        return self._array.shape[0]
+
+    # dunder methods are added for debugging convenience.
+    # Be warned, these create views on every call
+
+    def __iter__(self):
+        return iter(self.array)
+
+    def __len__(self):
+        """ number of in memory elements
+            note: len is supposed to match the number of elements returned by iter
+        """
+        return self.array.size
+
+    # note: handling of wraparounds, multi-slicing, etc. whether well defined or not here, is
+    #       propagated to the currently live view of the underlying array implementation, partly
+    #       because there are too many cases to handle with a small class like this.
+    def __getitem__(self, item):
+        return self.array[item]
+
+    def __setitem__(self, key, value):
+        self.array[key] = value
+
+    def extend(self, count, fill_value=None):
+        """
+        try to extend the current array by count positions, assign fill_value to these if one is provided.
+        """
+        if not (0 < count < self.free_count):
+            raise ValueError(f"fill count must be between 0 and current buffer size {self.free_count}, {count} received")
+        prevct = self.count
+        self.count += count
+        arr = self.array[prevct:]
+        if fill_value is not None:
+            arr.fill(fill_value)
+        return arr  
+
+
+    def drop_leading(self, count):
+        """ discard ct elements from memory starting from the current beginning of the in memory
+            portion
+        """
+        if count < 0:
+            raise ValueError("shift count cannot be negative")
+        elif count > self.count:
+            # This can arise when aggregating multiple sequences of non-uniform length.
+            # One sequence may depend on > 1 elements of another sequence, so a shift by some amount
+            # greater than what is contained here right now indicates no data was provided. For that reason
+            # we apply the entire shift to min_index, implicitly normalize the buffer, and set the number of live
+            # elements to 0 (so array.data returns an empty view)
+
+            self.begin_pos = 0
+            self.count = 0
+        else:
+            self.begin_pos += count
+            self.count -= count
+        self.min_index += count
+
+    def resize_buffer(self, size):
+        """ resize underlying buffer, raise an error if it would truncate live data """
+        if size < self.count:
+            raise ValueError(f"buffer size {size} is too small to accommodate {self.count} live elements")
+        data = self.array
+        self._array = np.empty(size, dtype=self._array.dtype)
+        self.array[:] = data
+
+    def append(self, data):
+        """ append to buffer. In most python interfaces, extend is used with iterables. This naming convention
+            maintains consistency with that, without checking explicit inheritance from Iterable, which numpy may
+            not adhere to strictly.
+        """
+        reqspace = data.size
+        if self.free_count < reqspace:
+            raise ValueError(f"appending {dat.size} elements would overflow available buffer space: {self.free_count}")
+        prevct = self.count
+        self.count += reqspace
+        self.array[prevct:] = data
+
+    def normalize_buffer(self):
+        """ normalize buffer layout so that retained data spans the positional range
+            0 to size - 1.
+            Since this is an inplace op, it can invalidate python iterators to this object.
+            It is intentionally left as an explicit op.
+        """
+        if self.begin_pos != 0:
+            self._array[:self.count] = self.array
+            self.begin_pos = 0
+
+
+def xcov(ts, mu, cmpto, out=None):
+    sseqct = ts.shape[0] - cmpto.shape[0] + 1
+    if sseqct > 0 and out is None:
+        out = np.empty(sseqct - minsep, dtype='d')
+    mps.crosscov(out, ts, mu, cmpto)
+    return out
+
+
+def mpx(ts, w):
+    if w < 2:
+        raise ValueError(f"Window length must be at least 2, received {w}")
+    sseqct = ts.shape[0] - w + 1
+    mu = np.empty(sseqct, dtype='d')
+    mu_s = np.empty(sseqct, dtype='d')  # window length w - 1 skipping first and last
+    invn = np.empty(sseqct, dtype='d')
+    minsep = w // 4
+    if sseqct <= minsep:
+        return np.full(sseqct, -1.0), np.full(sseqct, -1)
+    mps.windowed_mean(ts, mu, w)
+    mps.windowed_mean(ts[:-1], mu_s, w - 1)
+    mps.windowed_invcnorm(ts, mu, invn, w)
+    rbwd = ts[:sseqct - 1] - mu[:sseqct - 1]
+    cbwd = ts[:sseqct - 1] - mu_s[1:]
+    rfwd = ts[w:] - mu[1:]
+    cfwd = ts[w:] - mu_s[1:]
+
+    mp = np.full(sseqct, -1, dtype='d')
+    mpi = np.full(sseqct, -1, dtype='i')
+
+    first_row = ts[:w] - mu[0]
+    cov = np.empty(sseqct - minsep, dtype='d')
+
+    mps.crosscov(cov, ts[minsep:], mu[minsep:], first_row)
+
+    # roffset only applies when this is tiled by row, since otherwise the index would be wrong
+    mps.mpx_inner(cov, rbwd, rfwd, cbwd, cfwd, invn, mp, mpi, minsep, 0)
+
+    return mp, mpi
+
+
+class MpxStream:
+    """
+       This provides a simple implementation based on the buffered array class.
+
+    """
+
+    def __init__(self, sseqlen, minsep, maxsep=None, minbufsz=None):
+        if sseqlen < 2:
+            raise ValueError("subsequence lengths less than 2 do not admit a normalized representation")
+        elif maxsep is not None:
+            if not (0 < minsep < maxsep):
+                raise ValueError(f"minsep must be a positive value between 0 and maxsep if maxsep is provided, "
+                                 f"received minsep: {minsep}, maxsep: {maxsep}")
+        elif minsep < 1:
+            raise ValueError("non-positive minsep is not well defined")
+        # This object indexes by subsequence, not by time series element
+        self.sseqlen = sseqlen
+        self.minsep = minsep
+        self.maxsep = maxsep
+        if minbufsz is None:
+            if maxsep is None:
+                minbufsz = max(2 * sseqlen, 4096)
+            else:
+                minbufsz = (maxsep - minsep) + sseqlen - 1
+
+        # These are actually different sizes, but it's much easier to allocate them uniformly
+        # This way if they are very large, they can be aligned to a multiple of page size
+        #
+        # This works fine, since they each explicitly track the number of live elements at a given time      
+
+        # I'm using a leading underscore, which indicates that something should be private, to refer
+        # to the buffer data structure here and no underscore to refer to the live section of the array
+        self.mp = StreamArray(minbufsz)
+        self.mpi = StreamArray(minbufsz, dtype='i')
+        self.ts = StreamArray(minbufsz)
+        self.mu = StreamArray(minbufsz)
+        self.invn = StreamArray(minbufsz)
+        self.rbwd = StreamArray(minbufsz)
+        self.rfwd = StreamArray(minbufsz)
+        self.cbwd = StreamArray(minbufsz)
+        self.cfwd = StreamArray(minbufsz)
+        # unlike the others, cov is just scratch space
+
+        # so we don't include them in the object's buffers
+        self.first_row = None
+
+    # data classes have this as a method in 3.8+
+    # It's used here to cleanly call a method on all persistent sequences used by mpx
+    @property
+    def astuple(self):
+        return self.mp, self.mpi, self.ts, self.mu, self.invn, self.rbwd, self.rfwd, self.cbwd, self.cfwd
+
+    @property
+    def count(self):
+        return self.ts.count
+
+    @property
+    def sseqct(self):
+        return max(self.ts.count - self.sseqlen + 1, 0)
+
+    @property
+    def buffer_size(self):
+        """ buffer size """
+        return self.mp.size
+
+    def drop(self, ct):
+        """ discard ct elements from memory starting from the current beginning of the in memory
+            portion
+
+            I may need to adjust buffers
+        """
+        for seq in self.astuple:
+            seq.drop_leading(ct)
+
+    def normalize_buffers(self):
+        """ normalize buffer layout so that retained data spans the positional range
+            0 to size - 1
+        """
+        for seq in self.astuple:
+            seq.normalize_buffer()
+
+    def resize_buffer(self, size):
+        """ resize underlying buffer. size must accommodate the time series length rather than subsequence length.
+        """
+        if self.ts.count > size:
+            raise ValueError(
+                f"a resized buffer of size {size} is too small to retain a time series with  {self.ts.count} "
+                f"live elements")
+        elif size == self.count:
+            self.normalize_buffers()
+        else:
+            # Buffers are allocated uniformly, because they're typically close enough in length and this allows for
+            # allocating by powers of 2 if necessary
+            for buf in self.astuple:
+                buf.resize_buffer(size)
+
+    def append(self, data):
+
+        # This attempts to always leave things in a consistent state, regardless
+        # of whether 1 or more comparisons can be added.
+        updatedlen = self.ts.count + len(data)
+        if updatedlen > self.ts.free_count:
+            self.resize_buffer(2 * updatedlen)
+        prevct = self.sseqct
+        self.ts.append(data)
+        ts_ = self.ts[prevct:]
+        addct = self.sseqct - prevct
+        if addct == 0:
+            return
+        mu_ = self.mu.extend(addct)
+        mps.windowed_mean(ts_, mu_, self.sseqlen)
+        invn_ = self.invn.extend(addct)
+        mps.windowed_invcnorm(ts_, mu_, invn_, self.sseqlen)
+        self.mp.extend(count=addct, fill_value=-1.0)
+        self.mpi.extend(count=addct, fill_value=-1)
+
+        # It's easier to split these.
+        # The case of prevct == 0 has to account for difference arrays only
+        # containing subsequence count - 1 valid entries. For prevct != 0, we
+        # add addct new entries, with one mixing in prior data.
+
+        if prevct == 0 and addct == 1:
+            return
+        elif prevct < 2:
+            self.first_row = self.ts[:self.sseqlen] - self.mu[0]
+            mu_s = np.empty(addct-1, dtype='d')
+            mps.windowed_mean(self.ts[1:-1], mu_s, self.sseqlen-1)
+            self.rbwd.append(self.ts[:self.sseqct - 1] - self.mu[:-1])
+            self.cbwd.append(self.ts[:self.sseqct - 1] - mu_s)
+            self.rfwd.append(self.ts[self.sseqlen:] - self.mu[1:])
+            self.cfwd.append(self.ts[self.sseqlen:] - mu_s)
+        else:
+            ts_ = self.ts[prevct - 1:]
+            mu_ = self.mu[prevct - 1:]
+            mu_s = np.empty(addct, dtype='d')
+            mps.windowed_mean(ts_[1:-1], mu_s, self.sseqlen-1)
+            self.rbwd.append(ts_[:addct] - mu_[:-1])
+            self.cbwd.append(ts_[:addct] - mu_s)
+            self.rfwd.append(ts_[self.sseqlen:] - mu_[1:])
+            self.cfwd.append(ts_[self.sseqlen:] - mu_s)
+
+        diagaddct = addct - abs(prevct - self.minsep)
+        if diagaddct < 1:
+            return
+
+        minsep_ = self.sseqct - diagaddct
+        cov_ = np.empty(diagaddct, dtype='d')
+        xcov(self.ts[minsep_:], self.mu[minsep_:], self.first_row, out=cov_)
+
+        mps.mpx_inner(cov_,
+                      self.rbwd.array,
+                      self.rfwd.array,
+                      self.cbwd.array,
+                      self.cfwd.array,
+                      self.invn.array,
+                      self.mp.array,
+                      self.mpi.array,
+                      minsep_,
+                      self.mp.min_index)

--- a/matrixprofile/algorithms/streamingimpl.pyx
+++ b/matrixprofile/algorithms/streamingimpl.pyx
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+#cython: boundscheck=True, cdivision=True, wraparound=True
+import numpy as np
+from cython.view cimport array
+from libc.math cimport sqrt
+from matrixprofile.cycore import muinvn
+
+# These are here for convenience purposes for now
+# They can be factored out, as this module should primarily contain the buffering specific codes
+#
+
+cpdef windowed_mean(double [::1] ts, double[::1] mu, Py_ssize_t windowlen):
+     
+    # this could be inferred, but it's safer this way
+    if ts.shape[0] < windowlen:
+        raise ValueError(f"Window length {windowlen} exceeds the number of elements in the time series {ts.shape[0]}")
+    # safer to test this explicitly than infer the last parameter 
+    cdef Py_ssize_t windowct = ts.shape[0] - windowlen + 1
+    if windowct != mu.shape[0]:
+        raise ValueError(f"subsequence count {windowct} does not match output shape {mu.shape[0]}")
+    cdef double accum = ts[0];
+    cdef double resid = 0;
+    cdef Py_ssize_t i
+    cdef double m, n, p, q, r, s
+    for i in range(1, windowlen):
+        m = ts[i]
+        p = accum
+        accum += m
+        q = accum - p
+        resid += ((p - (accum - q)) + (m - q))
+    mu[0] = (accum + resid) / windowlen
+    for i in range(windowlen, ts.shape[0]):
+        m = ts[i - windowlen]
+        n = ts[i]
+        p = accum - m
+        q = p - accum
+        r = resid + ((accum - (p - q)) - (m + q))
+        accum = p + n
+        s = accum - p
+        resid = r + ((p - (accum - s)) + (n - s))
+        mu[i - windowlen + 1] = (accum + resid) / windowlen
+    return mu
+
+
+cpdef windowed_invcnorm(double[::1] ts, double[::1] mu, double[::1] invn, Py_ssize_t windowlen):
+    cdef Py_ssize_t windowct = ts.shape[0] - windowlen + 1
+    if not (windowct == mu.shape[0] == invn.shape[0]):
+        raise ValueError(f"window count {windowct} does not match output shapes {mu.shape[0]} and {invn.shape[0]}") 
+
+    cdef double accum = 0.0
+    cdef double m_
+    cdef Py_ssize_t i, j
+
+    for i in range(windowct):
+        m_ = mu[i]
+        accum = 0
+        for j in range(i, i + windowlen):
+            accum += (ts[j] - m_)**2
+        invn[i] = 1/sqrt(accum)
+    return invn
+
+
+cpdef normalize_one(double[::1] out, double[::1] ts, double mu, double sig):
+    cdef Py_ssize_t i,j
+    for i in range(out.shape[0]):
+        out[i] = (ts[i] - mu) / sig
+
+
+cpdef crosscov(double[::1] out, double[::1] ts, double[::1] mu, double[::1] cmpseq):
+    cdef Py_ssize_t sseqct = out.shape[0]
+    cdef double accum, m_
+    if sseqct != mu.shape[0]:
+        raise ValueError
+    elif cmpseq.shape[0] != ts.shape[0] - sseqct + 1:
+        raise ValueError
+    cdef Py_ssize_t i, j
+    for i in range(sseqct):
+        accum = 0.0
+        m_ = mu[i]
+        for j in range(cmpseq.shape[0]):
+            accum += (ts[i + j] - m_) * cmpseq[j]
+        out[i] = accum
+
+
+cpdef mpx_difeq(double [::1] out, double[::1] ts, double[::1] mu):
+    if not (ts.shape[0] == mu.shape[0] == out.shape[0]):
+        raise ValueError(f'time series of shape {ts.shape[0]} is incompatible with mean vector mu of shape {mu.shape[0]} and output shape {out.shape[0]}')
+    cdef Py_ssize_t i
+    for i in range(ts.shape[0]):
+        out[i] = ts[i] - mu[i]
+
+
+cpdef mpx_inner(double[::1] cov,
+                double[::1] r_bwd,
+                double[::1] r_fwd,
+                double[::1] c_bwd,
+                double[::1] c_fwd,
+                double[::1] invn,
+                double[::1] mp,
+                int[::1] mpi,
+                int minlag,
+                int roffset):
+    cdef int i, j, diag, row, col, cvpos
+    cdef double cv, corr_
+    cdef int subseqct = mp.shape[0]
+    # check full requirements for shape mismatches
+    if not ((cov.shape[0] + minlag) == mp.shape[0] == mpi.shape[0] == invn.shape[0]):
+        raise ValueError(f"these should match, cov-minlag:{cov.shape[0]+minlag}, mp:{mp.shape[0]}, mpi:{mpi.shape[0]}, invn:{invn.shape[0]}")
+    elif minlag < 1:
+        raise ValueError(f"minlag must be a positive integer, received {minlag}")
+    for diag in range(minlag, subseqct):
+        cvpos = diag - minlag
+        cv = cov[cvpos]
+        for row in range(subseqct - diag):
+            col = diag + row
+            if row > 0: 
+                cv -= r_bwd[row-1] * c_bwd[col-1]
+                cv += r_fwd[row-1] * c_fwd[col-1]
+            corr_ = cv * invn[row] * invn[col]
+            if corr_ > 1.0:
+                corr_ = 1.0
+            if corr_ > mp[row]:
+                mp[row] = corr_ 
+                mpi[row] = col + roffset
+            if corr_ > mp[col]:
+                mp[col] = corr_
+                mpi[col] = row + roffset
+    
+
+cpdef mpx_parallel(double[::1] ts, int w, int cross_correlation, int n_jobs):
+    """
+    The MPX algorithm computes the matrix profile without using the FFT. Right
+    now it only supports single dimension self joins. 
+ 
+    The experimental version uses a slightly simpler factorization in an effort to 
+    avoid cases of very ill conditioned products on time series with streams of zeros
+    or missing data.
+
+    Parameters
+    ----------
+    ts : array_like
+        The time series to compute the matrix profile for.
+    w : int
+        The window size.
+    cross_correlation : int
+        Flag (0, 1) to determine if cross_correlation distance should be
+        returned. It defaults to Euclidean Distance (0).
+    n_jobs : int, Default = 1
+        Number of cpu cores to use.
+    
+    Returns
+    -------
+    (array_like, array_like) :
+        The matrix profile (distance profile, profile index).
+
+    """
+    if w < 2: 
+        raise ValueError('subsequence length is too short to admit a normalized representation')
+    
+    cdef int i, j, diag, row, col
+    cdef double cov_, corr_
+    
+    cdef int minlag = w // 4
+    cdef int subseqcount = ts.size - w + 1
+
+    if subseqcount < 1 + minlag:  
+        raise ValueError('time series is too short relative to subsequence length w')
+    
+    cdef double[::1] mu, mu_s, invnorm
+    mu, invnorm  = muinvn(ts, w)
+    mu_s, _ = muinvn(ts[:ts.size-1], w-1)
+    mprof_ = np.empty(subseqcount, dtype='d')
+    mprofidx_ = np.empty(subseqcount, dtype='i')
+    cdef double[::1] mprof = mprof_
+    cdef int[::1] mprofidx = mprofidx_ 
+
+    for i in range(subseqcount):
+        mprof[i] = -1.0
+
+    cdef double[::1] r_bwd = array(shape=(subseqcount-1,), itemsize=sizeof(double), format='d')
+    cdef double[::1] c_bwd = array(shape=(subseqcount-1,), itemsize=sizeof(double), format='d')
+    cdef double[::1] r_fwd = array(shape=(subseqcount-1,), itemsize=sizeof(double), format='d')
+    cdef double[::1] c_fwd = array(shape=(subseqcount-1,), itemsize=sizeof(double), format='d')
+   
+    for i in range(subseqcount-1):
+        r_bwd[i] = ts[i] - mu[i]
+        c_bwd[i] = ts[i] - mu_s[i+1]
+        r_fwd[i] = ts[i+w] - mu[i+1]
+        c_fwd[i] = ts[i+w] - mu_s[i+1]
+
+    cdef double[::1] first_row = array(shape=(w,), itemsize=sizeof(double), format='d')
+    cdef double m_ = mu[0]
+    for i in range(w):
+        first_row[i] = ts[i] - m_     
+
+    for diag in range(minlag, subseqcount):
+        cov_ = 0 
+        for i in range(diag, diag + w):
+            cov_ += (ts[i] - mu[diag]) * first_row[i-diag]
+
+        for row in range(subseqcount - diag):
+            col = diag + row
+            if row > 0: 
+                cov_ -= r_bwd[row-1] * c_bwd[col-1] 
+                cov_ += r_fwd[row-1] * c_fwd[col-1]
+            corr_ = cov_ * invnorm[row] * invnorm[col]
+            if corr_ > 1.0:
+                corr_ = 1.0
+            if corr_ > mprof[row]:
+                mprof[row] = corr_ 
+                mprofidx[row] = col 
+            if corr_ > mprof[col]:
+                mprof[col] = corr_
+                mprofidx[col] = row
+    
+    if cross_correlation == 0:
+        for i in range(subseqcount):
+            mprof[i] = sqrt(2 * w * (1 - mprof[i]))
+    
+    return mprof_, mprofidx_
+
+

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,11 @@ extensions.append(Extension(
     include_dirs=[numpy.get_include()],
 ))
 
+extensions.append(Extension(
+   'matrixprofile.streamingimpl',
+   ['matrixprofile/algorithms/streamingimpl.pyx'],
+   include_dirs=[numpy.get_include()]))
+
 matplot = 'matplotlib>=3.0.3'
 scipy = 'scipy>=1.3.2,<2.0.0'
 if sys.version_info.major == 3:


### PR DESCRIPTION
This needs more cleanup and merging, but this represents what I had in mind for streaming operations. For simplicity, this maintains a consistent view of a time series at any given time, regardless of whether all arrays can be populated or any comparisons can be made. 

I included a buffering class to help facilitate this. Its reference interface is provided as an abstract base class. This requires a small amount of care in that anytime you add data, you must assume that existing iterators may be clobbered. Other than that, it simplifies the required slicing considerably. 

This may still have minor issues left. It includes the formula updates. The version provided deals with a single time series. Cross comparisons use the same formula. I'll need to add an mpx_cross_inner and some interface for it.

