### PR TITLE
Fix missing default arguments specified in docstring. Change boolean …

### DIFF
--- a/matrixprofile/algorithms/cympx.pyx
+++ b/matrixprofile/algorithms/cympx.pyx
@@ -27,7 +27,7 @@ from matrixprofile.cycore import muinvn
 @cython.boundscheck(False)
 @cython.cdivision(True)
 @cython.wraparound(False)
-cpdef mpx_parallel(double[:] ts, int w, bint cross_correlation=0, int n_jobs=1):
+cpdef mpx_parallel(double[::1] ts, int w, bint cross_correlation=0, int n_jobs=1):
     """
     The MPX algorithm computes the matrix profile without using the FFT. Right
     now it only supports single dimension self joins.
@@ -61,16 +61,16 @@ cpdef mpx_parallel(double[:] ts, int w, bint cross_correlation=0, int n_jobs=1):
     cdef double c, c_cmp
 
     stats = muinvn(ts, w)
-    cdef double[:] mu = stats[0]
-    cdef double[:] sig = stats[1]
+    cdef double[::1] mu = stats[0]
+    cdef double[::1] sig = stats[1]
     
-    cdef double[:] df = np.empty(profile_len, dtype='d')
-    cdef double[:] dg = np.empty(profile_len, dtype='d')
-    cdef np.ndarray[np.double_t, ndim=1] mp = np.full(profile_len, -1, dtype='d')
-    cdef np.ndarray[np.int_t, ndim=1] mpi = np.full(profile_len, np.nan, dtype='int')
+    cdef double[::1] df = np.empty(profile_len, dtype='d')
+    cdef double[::1] dg = np.empty(profile_len, dtype='d')
+    cdef np.ndarray[np.double_t, ndim=1] mp = np.full(profile_len, -1.0, dtype='d')
+    cdef np.ndarray[np.int_t, ndim=1] mpi = np.full(profile_len, -1, dtype='int')
     
-    cdef double[:,:] tmp_mp = np.full((profile_len, n_jobs), -1, dtype='d')
-    cdef np.int_t[:,:] tmp_mpi = np.full((profile_len, n_jobs), np.nan, dtype='int')
+    cdef double[:,::1] tmp_mp = np.full((profile_len, n_jobs), -1.0, dtype='d')
+    cdef np.int_t[:,::1] tmp_mpi = np.full((profile_len, n_jobs), -1, dtype='int')
     
     # this is where we compute the diagonals and later the matrix profile
     df[0] = 0
@@ -120,7 +120,7 @@ cpdef mpx_parallel(double[:] ts, int w, bint cross_correlation=0, int n_jobs=1):
 @cython.boundscheck(False)
 @cython.cdivision(True)
 @cython.wraparound(False)
-cpdef mpx_ab_parallel(double[:] ts, double[:] query, int w, bint cross_correlation=0, int n_jobs=1):
+cpdef mpx_ab_parallel(double[::1] ts, double[::1] query, int w, bint cross_correlation=0, int n_jobs=1):
     """
     The MPX algorithm computes the matrix profile without using the FFT. This
     specific implementation includes similarity join (AB join).
@@ -154,27 +154,27 @@ cpdef mpx_ab_parallel(double[:] ts, double[:] query, int w, bint cross_correlati
     cdef int profile_lenb = qn - w + 1
 
     stats_a = muinvn(ts, w)
-    cdef double[:] mua = stats_a[0]
-    cdef double[:] siga = stats_a[1]
+    cdef double[::1] mua = stats_a[0]
+    cdef double[::1] siga = stats_a[1]
 
     stats_b = muinvn(query, w)
-    cdef double[:] mub = stats_b[0]
-    cdef double[:] sigb = stats_b[1]
+    cdef double[::1] mub = stats_b[0]
+    cdef double[::1] sigb = stats_b[1]
     
-    cdef double[:] diff_fa = np.empty(profile_len, dtype='d')
-    cdef double[:] diff_ga = np.empty(profile_len, dtype='d')
-    cdef double[:] diff_fb = np.empty(profile_lenb, dtype='d')
-    cdef double[:] diff_gb = np.empty(profile_lenb, dtype='d')
+    cdef double[::1] diff_fa = np.empty(profile_len, dtype='d')
+    cdef double[::1] diff_ga = np.empty(profile_len, dtype='d')
+    cdef double[::1] diff_fb = np.empty(profile_lenb, dtype='d')
+    cdef double[::1] diff_gb = np.empty(profile_lenb, dtype='d')
 
-    cdef np.ndarray[np.double_t, ndim=1] mp = np.full(profile_len, -1, dtype='d')
-    cdef np.ndarray[np.int_t, ndim=1] mpi = np.full(profile_len, np.nan, dtype='int')
-    cdef np.ndarray[np.double_t, ndim=1] mpb = np.full(profile_lenb, -1, dtype='d')
-    cdef np.ndarray[np.int_t, ndim=1] mpib = np.full(profile_lenb, np.nan, dtype='int')
+    cdef np.ndarray[np.double_t, ndim=1] mp = np.full(profile_len, -1.0, dtype='d')
+    cdef np.ndarray[np.int_t, ndim=1] mpi = np.full(profile_len, -1, dtype='int')
+    cdef np.ndarray[np.double_t, ndim=1] mpb = np.full(profile_lenb, -1.0, dtype='d')
+    cdef np.ndarray[np.int_t, ndim=1] mpib = np.full(profile_lenb, -1, dtype='int')
     
-    cdef double[:,:] tmp_mp = np.full((profile_len, n_jobs), -1, dtype='d')
-    cdef np.int_t[:,:] tmp_mpi = np.full((profile_len, n_jobs), np.nan, dtype='int')
-    cdef double[:,:] tmp_mpb = np.full((profile_lenb, n_jobs), -1, dtype='d')
-    cdef np.int_t[:,:] tmp_mpib = np.full((profile_lenb, n_jobs), np.nan, dtype='int')
+    cdef double[:,::1] tmp_mp = np.full((profile_len, n_jobs), -1.0, dtype='d')
+    cdef np.int_t[:,::1] tmp_mpi = np.full((profile_len, n_jobs), -1, dtype='int')
+    cdef double[:,::1] tmp_mpb = np.full((profile_lenb, n_jobs), -1.0, dtype='d')
+    cdef np.int_t[:,::1] tmp_mpib = np.full((profile_lenb, n_jobs), -1, dtype='int')
     
     # # this is where we compute the diagonals and later the matrix profile
     diff_fa[0] = 0

--- a/matrixprofile/algorithms/cympx.pyx
+++ b/matrixprofile/algorithms/cympx.pyx
@@ -27,7 +27,7 @@ from matrixprofile.cycore import muinvn
 @cython.boundscheck(False)
 @cython.cdivision(True)
 @cython.wraparound(False)
-cpdef mpx_parallel(double[:] ts, int w, int cross_correlation, int n_jobs):
+cpdef mpx_parallel(double[:] ts, int w, bint cross_correlation=0, int n_jobs=1):
     """
     The MPX algorithm computes the matrix profile without using the FFT. Right
     now it only supports single dimension self joins.
@@ -38,7 +38,7 @@ cpdef mpx_parallel(double[:] ts, int w, int cross_correlation, int n_jobs):
         The time series to compute the matrix profile for.
     w : int
         The window size.
-    cross_correlation : int
+    cross_correlation : bint
         Flag (0, 1) to determine if cross_correlation distance should be
         returned. It defaults to Euclidean Distance (0).
     n_jobs : int, Default = 1
@@ -120,7 +120,7 @@ cpdef mpx_parallel(double[:] ts, int w, int cross_correlation, int n_jobs):
 @cython.boundscheck(False)
 @cython.cdivision(True)
 @cython.wraparound(False)
-cpdef mpx_ab_parallel(double[:] ts, double[:] query, int w, int cross_correlation, int n_jobs):
+cpdef mpx_ab_parallel(double[:] ts, double[:] query, int w, bint cross_correlation=0, int n_jobs=1):
     """
     The MPX algorithm computes the matrix profile without using the FFT. This
     specific implementation includes similarity join (AB join).
@@ -133,7 +133,7 @@ cpdef mpx_ab_parallel(double[:] ts, double[:] query, int w, int cross_correlatio
         The query o compute the matrix profile for.
     w : int
         The window size.
-    cross_correlation : int
+    cross_correlation : bint
         Flag (0, 1) to determine if cross_correlation distance should be
         returned. It defaults to Euclidean Distance (0).
     n_jobs : int, Default = 1
@@ -271,7 +271,7 @@ cpdef mpx_ab_parallel(double[:] ts, double[:] query, int w, int cross_correlatio
             if eucdist == mxdist:
                 eucdist = INFINITY
             mpb[i] = eucdist
-    elif cross_correlation == 1:
+    else:
         for i in range(profile_len):
             if mp[i] > 1:
                 mp[i] = 1


### PR DESCRIPTION
This switches the use of C integer types to the correct Cython type for integer cast as a boolean. This is not the same as the boolean type that requires libcpp.

Filled in the missing default arguments specified by the docstrings of these functions.

Changed elif to else, since it's the line refers to a flag with only 2 values (now cast to the correct type).

