### PR TITLE
Rework difference equations to omit leading zero. This change avoids …

### DIFF
--- a/matrixprofile/algorithms/cympx.pyx
+++ b/matrixprofile/algorithms/cympx.pyx
@@ -63,8 +63,8 @@ cpdef mpx_parallel(double[::1] ts, int w, bint cross_correlation=0, int n_jobs=1
     cdef double[::1] mu = stats[0]
     cdef double[::1] sig = stats[1]
     
-    cdef double[::1] df = np.empty(profile_len, dtype='d')
-    cdef double[::1] dg = np.empty(profile_len, dtype='d')
+    cdef double[::1] df = np.empty(profile_len-1, dtype='d')
+    cdef double[::1] dg = np.empty(profile_len-1, dtype='d')
     cdef np.ndarray[np.double_t, ndim=1] mp = np.full(profile_len, -1.0, dtype='d')
     cdef np.ndarray[np.int_t, ndim=1] mpi = np.full(profile_len, -1, dtype='int')
     
@@ -153,10 +153,10 @@ cpdef mpx_ab_parallel(double[::1] ts, double[::1] query, int w, bint cross_corre
     cdef double[::1] mu_b = stats_b[0]
     cdef double[::1] sig_b = stats_b[1]
     
-    cdef double[::1] df_a = np.empty(profile_len_a, dtype='d')
-    cdef double[::1] dg_a = np.empty(profile_len_a, dtype='d')
-    cdef double[::1] df_b = np.empty(profile_len_b, dtype='d')
-    cdef double[::1] dg_b = np.empty(profile_len_b, dtype='d')
+    cdef double[::1] df_a = np.empty(profile_len_a-1, dtype='d')
+    cdef double[::1] dg_a = np.empty(profile_len_a-1, dtype='d')
+    cdef double[::1] df_b = np.empty(profile_len_b-1, dtype='d')
+    cdef double[::1] dg_b = np.empty(profile_len_b-1, dtype='d')
 
     cdef np.ndarray[np.double_t, ndim=1] mp_a = np.full(profile_len_a, -1.0, dtype='d')
     cdef np.ndarray[np.int_t, ndim=1] mpi_a = np.full(profile_len_a, -1, dtype='int')


### PR DESCRIPTION
…some error prone behavior in streaming and certain tiling patterns, as the leading zero is only correct if mpx is run starting from index 0 rather than some other point in the time series.

The tolerance switch to e-8 is also present. I found in rare cases, e-10 was too tight here. Typically absolute tolerance would be low, but relative tolerance would be just over the threshold on 1-2 elements out of roughly 16000. FMA might make a difference, but we aren't using it here. 