### PR TITLE
Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 
 before_install:
   - |

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ Currently, we support the following versions of Python:
 * 3.6
 * 3.7
 * 3.8
+* 3.9
 
 Python 2 is no longer supported. There are earlier versions of this library that support Python 2.
 


### PR DESCRIPTION
Tested locally that all the tests are passing against [Python 3.9.1](https://www.python.org/downloads/release/python-391/).

- update the travis build list with python 3.9
- updated the README

closes #64 

---

Here are the steps to reproduce:

```bash
python3.9 -m venv venv
source activate venv/bin/activate
pip install -e .
pip install -r requirements.txt
pytest tests
```