### PR TITLE
Add source distribution artifacts 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,8 @@ jobs:
       script:
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*.whl --verbose
+        - python setup.py sdist --formats=gztar,zip
+        - twine upload dist/* --verbose
       after_success:
         - ls wheelhouse/*.whl
     # Deploy on mac

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,8 @@ jobs:
       script:
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*.whl --verbose
-        - python setup.py sdist --formats=gztar,zip
-        - twine upload dist/* --verbose
+        - python setup.py sdist --formats=gztar
+        - twine upload dist/*.tar.gz --verbose
       after_success:
         - ls wheelhouse/*.whl
     # Deploy on mac


### PR DESCRIPTION
- updated travis to build and upload a source distributions as `.zip` and `.tar.gz` 

closes #61 