### PR TITLE
fix: update protobuf to 3.18.3

### DIFF
--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -48,3 +48,6 @@
 
 # 1.1.10 (2021-01-16)
 - Adjust absolute paths to relative - deveops building wheels
+
+# 1.1.11 (2022-09-29)
+- Update protobuf dependancy to 3.18.3 in order to resolve [CVE-2021-22570](https://nvd.nist.gov/vuln/detail/cve-2021-22570) and [CVE-2022-1941](https://github.com/matrix-profile-foundation/matrixprofile/issues/98)

--- a/python2-requirements.txt
+++ b/python2-requirements.txt
@@ -3,7 +3,7 @@ matplotlib
 pytest>=3.5.1
 setuptools>=39.1.0
 cython>=0.x
-protobuf>=3.11.2,<4.0.0
+protobuf>=3.18.3,<4.0.0
 scipy<2.0.0
 sphinx
 nbsphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib>=3.0.3
 pytest>=3.5.1
 setuptools>=39.1.0
 cython>=0.x
-protobuf>=3.11.2,<4.0.0
+protobuf>=3.18.3,<4.0.0
 scipy>=1.3.2,<2.0.0
 sphinx
 nbsphinx

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
     include_package_data=True,
     packages = setuptools.find_packages(),
     setup_requires=['cython>=0.x', 'wheel'],
-    install_requires=['numpy>=1.16.2', matplot, 'protobuf>=3.11.2,<4.0.0', scipy],
+    install_requires=['numpy>=1.16.2', matplot, 'protobuf>=3.18.3,<4.0.0', scipy],
     ext_modules=cythonize(extensions),
     include_dirs=[numpy.get_include()],
     classifiers=[

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
-__version_info__ = (1, 1, 10)
+__version_info__ = (1, 1, 11)
 __version__ = '.'.join(map(str, __version_info__))
 MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION = __version_info__


### PR DESCRIPTION
Closes https://github.com/matrix-profile-foundation/matrixprofile/issues/98 and Fix for [CVE-2021-22570](https://nvd.nist.gov/vuln/detail/cve-2021-22570)